### PR TITLE
Improve readme by not telling user to replace backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,32 +57,30 @@ try MyWebsite().publish(using: [
 
 3. Write highlighted codes!
 
-Please replace ''' with ``` backticks in codeblocks.
-
 In your markdown file, specify language after ``` to get correct highlight. 
-```markdown
-'''swift
+````markdown
+```swift
 let str = "This is Swift code."
 print(str)
-'''
 ```
+````
 
 Specify code as `python`
-```markdown
-'''python
+````markdown
+```python
 str = "This is also Swift code."
 print(str)
-'''
 ```
+````
 
 
 If no language is specified, `swift` syntax will be used as default. 
-```markdown
-'''
+````markdown
+```
 let str = "This is also Swift code."
 print(str)
-'''
 ```
+````
 
 
 


### PR DESCRIPTION
No need to tell user to replace single quotes with backticks.

Markdown does support use of 3 backticks in code block if you use 4 backticks to create the code block.