### PR TITLE
Add platforms to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SwiftPygmentsPublishPlugin",
-            dependencies: ["SwiftPygments", "Publish"]),
+            dependencies: ["SwiftPygments", .product(name: "Publish", package: "publish")]),
         .testTarget(
             name: "SwiftPygmentsPublishPluginTests",
             dependencies: ["SwiftPygmentsPublishPlugin", "SwiftPygments"]),

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftPygmentsPublishPlugin",
+    platforms: [.macOS(.v12)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Without this builds fail with:

```
$ swift build
error: the library 'SwiftPygmentsPublishPlugin' requires macos 10.13, but depends on the product 'Publish' which requires macos 12.0; consider changing the library 'SwiftPygmentsPublishPlugin' to require macos 12.0 or later, or the product 'Publish' to require macos 10.13 or earlier.
```