### PR TITLE
Add a single thread for Pygments processing

### DIFF
--- a/Sources/SwiftPygmentsPublishPlugin/PygmentsActor.swift
+++ b/Sources/SwiftPygmentsPublishPlugin/PygmentsActor.swift
@@ -1,0 +1,45 @@
+import SwiftPygments
+
+internal var globalPygmentsActor = PygmentsActor()
+
+actor PygmentsActor {
+    
+    internal func highlight(html: String, markdown: Substring) -> String {
+        // Determine if the codeblock is wrapped by ``` or ````
+        var backticks : String
+        if markdown.hasPrefix("````") {
+            backticks = "````"
+        } else {
+            backticks = "```"
+        }
+        
+        var markdown = String(markdown.dropFirst(backticks.count))
+        
+        guard !markdown.hasPrefix("no-highlight") else {
+            return html
+        }
+        
+        // Default: Swift
+        var lexer : Pygments.Lexer = .swift
+        
+        if !markdown.hasPrefix("\n"),
+            let language = markdown.split(separator: "\n").first,
+            let aLexer = Pygments.Lexer.named(String(language).trimmingCharacters(in: .whitespacesAndNewlines)) {
+            // Found language matching. Override default lexer.
+            lexer = aLexer
+        }
+        markdown = String(markdown
+            .drop(while: { !$0.isNewline })
+            .dropFirst()
+            .dropLast("\n\(backticks)".count)
+        )
+        
+        var highlighted = Pygments.html(String(markdown), use: lexer)
+        highlighted = highlighted.replacingOccurrences(of: "<pre>", with: "")
+        highlighted = highlighted.replacingOccurrences(of: "</pre>", with: "")
+        highlighted = highlighted.trimmingCharacters(in: .newlines)
+        
+        return "<pre><code>" + highlighted + "</code></pre>"
+    }
+    
+}

--- a/Sources/SwiftPygmentsPublishPlugin/SwiftPygmentsPublishPlugin.swift
+++ b/Sources/SwiftPygmentsPublishPlugin/SwiftPygmentsPublishPlugin.swift
@@ -1,6 +1,7 @@
 import SwiftPygments
 import Publish
 import Ink
+import Foundation
 
 public extension Plugin {
     
@@ -17,41 +18,19 @@ public extension Plugin {
 public extension Modifier {
     static func pygmentsCodeBlocks() -> Self {
         return Modifier(target: .codeBlocks) { html, markdown in
-            // Determine if the codeblock is wrapped by ``` or ````
-            var backticks : String
-            if markdown.hasPrefix("````") {
-                backticks = "````"
-            } else {
-                backticks = "```"
+            
+            let semaphore = DispatchSemaphore(value: 0)
+            var result: String?
+            let completionHandler = { result = $0 }
+            
+            Task {
+                let result = await globalPygmentsActor.highlight(html: html, markdown: markdown)
+                completionHandler(result)
+                semaphore.signal()
             }
             
-            var markdown = String(markdown.dropFirst(backticks.count))
-            
-            guard !markdown.hasPrefix("no-highlight") else {
-                return html
-            }
-            
-            // Default: Swift
-            var lexer : Pygments.Lexer = .swift
-            
-            if !markdown.hasPrefix("\n"),
-                let language = markdown.split(separator: "\n").first,
-                let aLexer = Pygments.Lexer.named(String(language).trimmingCharacters(in: .whitespacesAndNewlines)) {
-                // Found language matching. Override default lexer.
-                lexer = aLexer
-            }
-            markdown = String(markdown
-                .drop(while: { !$0.isNewline })
-                .dropFirst()
-                .dropLast("\n\(backticks)".count)
-            )
-            
-            var highlighted = Pygments.html(String(markdown), use: lexer)
-            highlighted = highlighted.replacingOccurrences(of: "<pre>", with: "")
-            highlighted = highlighted.replacingOccurrences(of: "</pre>", with: "")
-            highlighted = highlighted.trimmingCharacters(in: .newlines)
-            
-            return "<pre><code>" + highlighted + "</code></pre>"
+            semaphore.wait()
+            return result!
         }
     }
 }


### PR DESCRIPTION
Pygments (or PythonKit, not sure which) doesn't do well with the multi-threaded piplines Publish uses to parse Markdown files. I've added a global Actor to disable concurrent syntax highlighting, and forced Publish to access this actor sequentially.